### PR TITLE
데이터베이스 스키마 & JPA 레포지토리 생성

### DIFF
--- a/src/main/java/com/ddoddii/resume/ResumeApplication.java
+++ b/src/main/java/com/ddoddii/resume/ResumeApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ResumeApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ResumeApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ResumeApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/ddoddii/resume/dto/JwtTokenDTO.java
+++ b/src/main/java/com/ddoddii/resume/dto/JwtTokenDTO.java
@@ -1,0 +1,12 @@
+package com.ddoddii.resume.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class JwtTokenDTO {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/ddoddii/resume/jwt/JwtFilter.java
+++ b/src/main/java/com/ddoddii/resume/jwt/JwtFilter.java
@@ -1,0 +1,46 @@
+package com.ddoddii.resume.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+@Component
+public class JwtFilter extends GenericFilterBean {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private TokenProvider tokenProvider;
+
+    public JwtFilter(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        String token = resolveToken((HttpServletRequest) servletRequest);
+
+        if (token != null && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/jwt/TokenProvider.java
+++ b/src/main/java/com/ddoddii/resume/jwt/TokenProvider.java
@@ -1,0 +1,102 @@
+package com.ddoddii.resume.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TokenProvider implements InitializingBean {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private final String secret;
+    private final long tokenValidityInMilliseconds;
+    private Key key;
+
+    public TokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds) {
+        this.secret = secret;
+        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+    }
+
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        // 토큰의 expire 시간을 설정
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities) // 정보 저장
+                .signWith(key, SignatureAlgorithm.HS512) // 사용할 암호화 알고리즘과 , signature 에 들어갈 secret값 세팅
+                .setExpiration(validity) // set Expire Time 해당 옵션 안넣으면 expire안함
+                .compact();
+    }
+
+    //토큰을 받아서 Authentication 객체를 반환
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    //토큰의 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 서명입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 서명입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+
+}

--- a/src/main/java/com/ddoddii/resume/model/BaseEntity.java
+++ b/src/main/java/com/ddoddii/resume/model/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.ddoddii.resume.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
+
+}

--- a/src/main/java/com/ddoddii/resume/model/Evaluation.java
+++ b/src/main/java/com/ddoddii/resume/model/Evaluation.java
@@ -1,0 +1,47 @@
+package com.ddoddii.resume.model;
+
+import com.ddoddii.resume.model.eunm.QuestionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "evaluation")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class Evaluation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Evaluation 이 Interview의 FK를 가지고 있다 = 연관관계의 주인이다
+    @OneToOne
+    @JoinColumn(name = "interview_id")
+    private Interview interview;
+
+    @Column(name = "question_id")
+    private Long question_id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_type")
+    private QuestionType questionType;
+
+    @Column(name = "user_answer")
+    private String userAnswer;
+
+    @Column(name = "gpt_evaluation")
+    private String gptEvaluation;
+}

--- a/src/main/java/com/ddoddii/resume/model/Interview.java
+++ b/src/main/java/com/ddoddii/resume/model/Interview.java
@@ -1,0 +1,76 @@
+package com.ddoddii.resume.model;
+
+import com.ddoddii.resume.model.eunm.InterviewFormat;
+import com.ddoddii.resume.model.eunm.InterviewRound;
+import com.ddoddii.resume.model.eunm.InterviewTarget;
+import com.ddoddii.resume.model.eunm.InterviewType;
+import com.ddoddii.resume.model.question.PersonalQuestion;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+@ManyToOne : 자식 엔티티(FK를 들고있는 쪽)
+@ManyToOne(optional = false) : FK 에 null 값을 허용하지 않는다.
+@OneToMany : 부모 엔티티(참조 당하는 쪽)
+Interview(다) - Resume(1) : 양방향
+Interview(다) - User(1) : 양방향
+ */
+
+@Entity
+@Table(name = "interview")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class Interview extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interview_target")
+    private InterviewTarget interviewTarget;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interview_round")
+    private InterviewRound interviewRound;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interview_format")
+    private InterviewFormat interviewFormat;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interview_type")
+    private InterviewType interviewType;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "id")
+    private Resume resume;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "resume")
+    private List<PersonalQuestion> personalQuestions;
+
+    @OneToOne(mappedBy = "resume")
+    private Evaluation evaluation;
+
+
+}

--- a/src/main/java/com/ddoddii/resume/model/Position.java
+++ b/src/main/java/com/ddoddii/resume/model/Position.java
@@ -1,8 +1,0 @@
-package com.ddoddii.resume.model;
-
-public enum Position {
-    FRONTEND_DEVELOPER,
-    BACKEND_DEVELOPER,
-    ML_DEVELOPER,
-    MOBILE_DEVELOPER
-}

--- a/src/main/java/com/ddoddii/resume/model/Resume.java
+++ b/src/main/java/com/ddoddii/resume/model/Resume.java
@@ -1,5 +1,7 @@
 package com.ddoddii.resume.model;
 
+import com.ddoddii.resume.model.eunm.Position;
+import com.ddoddii.resume.model.question.PersonalQuestion;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,15 +11,21 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "resumes")
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
-@Setter
-public class Resume {
+@Builder
+public class Resume extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,4 +41,10 @@ public class Resume {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "resume")
+    private List<Interview> interviews;
+
+    @OneToMany(mappedBy = "resume")
+    private List<PersonalQuestion> personalQuestions;
 }

--- a/src/main/java/com/ddoddii/resume/model/User.java
+++ b/src/main/java/com/ddoddii/resume/model/User.java
@@ -1,5 +1,6 @@
 package com.ddoddii.resume.model;
 
+import com.ddoddii.resume.model.eunm.RoleType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,9 +11,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
@@ -20,9 +23,12 @@ import lombok.Setter;
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = "user_id")
         })
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Getter
 @Setter
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,10 +50,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     private RoleType role;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
     @OneToMany(mappedBy = "user")
     private List<Resume> resumes;
 
+    @OneToMany(mappedBy = "user")
+    private List<Interview> interviews;
 }

--- a/src/main/java/com/ddoddii/resume/model/company/CompanyDept.java
+++ b/src/main/java/com/ddoddii/resume/model/company/CompanyDept.java
@@ -1,0 +1,34 @@
+package com.ddoddii.resume.model.company;
+
+import com.ddoddii.resume.model.eunm.CompanyDepartment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "company_dept", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "dept")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class CompanyDept {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dept")
+    private CompanyDepartment dept;
+}

--- a/src/main/java/com/ddoddii/resume/model/company/CompanyJob.java
+++ b/src/main/java/com/ddoddii/resume/model/company/CompanyJob.java
@@ -1,0 +1,32 @@
+package com.ddoddii.resume.model.company;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "company_job", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "job")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class CompanyJob {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(name = "job")
+    private String job;
+}

--- a/src/main/java/com/ddoddii/resume/model/company/CompanyName.java
+++ b/src/main/java/com/ddoddii/resume/model/company/CompanyName.java
@@ -1,0 +1,30 @@
+package com.ddoddii.resume.model.company;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "company_name", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "name")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class CompanyName {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String name;
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/CompanyDepartment.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/CompanyDepartment.java
@@ -1,0 +1,22 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum CompanyDepartment {
+    TECH("개발"),
+    HR("인사"),
+    ACCOUNT("회계"),
+    FINANCE("재무"),
+    MANAGEMENT("총무관리"),
+    SALES("영업"),
+    MARKETING("마케팅"),
+    CONTENTS("콘텐츠");
+
+
+    private String name;
+
+    CompanyDepartment(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/InterviewFormat.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/InterviewFormat.java
@@ -1,0 +1,17 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum InterviewFormat {
+    ONE_TO_ONE("1:1"),
+    ONE_TO_MANY("1:다"),
+    MANY_TO_ONE("다:1"),
+    MANY_TO_MANY("다:다");
+
+    private String name;
+
+    InterviewFormat(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/InterviewRound.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/InterviewRound.java
@@ -1,0 +1,18 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum InterviewRound {
+    
+    FIRST("1차 면접"),
+    SECOND("2차 면접"),
+    THIRD("3차 면접"),
+    FOURTH("4차 면접");
+    private String name;
+
+    InterviewRound(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/InterviewTarget.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/InterviewTarget.java
@@ -1,0 +1,17 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum InterviewTarget {
+    AI("AI"),
+    WORKING_STAFF("실무진"),
+    HR("인사팀"),
+    CEO("임원진");
+
+    private String name;
+
+    InterviewTarget(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/InterviewType.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/InterviewType.java
@@ -1,0 +1,16 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum InterviewType {
+    GENERAL("일반면접"),
+    PT("PT면접"),
+    DEBATE("토론면접");
+
+    private String name;
+
+    InterviewType(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/Position.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/Position.java
@@ -1,0 +1,20 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum Position {
+    FRONTEND_DEVELOPER("프런트엔드 개발자"),
+    BACKEND_DEVELOPER("백엔드 개발자"),
+    ML_DEVELOPER("머신러닝 엔지니어"),
+    MOBILE_DEVELOPER("모바일 개발자"),
+    INFRA("인프라"),
+    SECURITY("보안"),
+    MANAGEMENT("기획자");
+
+    private String name;
+
+    Position(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/QuestionType.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/QuestionType.java
@@ -1,0 +1,17 @@
+package com.ddoddii.resume.model.eunm;
+
+import lombok.Getter;
+
+@Getter
+public enum QuestionType {
+    TECH("기술질문"),
+    BEHAVIOR("인성질문"),
+    INTRODUCE("자기소개"),
+    PERSONAL("개인질문");
+
+    private String name;
+
+    QuestionType(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ddoddii/resume/model/eunm/RoleType.java
+++ b/src/main/java/com/ddoddii/resume/model/eunm/RoleType.java
@@ -1,4 +1,4 @@
-package com.ddoddii.resume.model;
+package com.ddoddii.resume.model.eunm;
 
 public enum RoleType {
     USER,

--- a/src/main/java/com/ddoddii/resume/model/question/BaseQuestionEntity.java
+++ b/src/main/java/com/ddoddii/resume/model/question/BaseQuestionEntity.java
@@ -1,0 +1,32 @@
+package com.ddoddii.resume.model.question;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseQuestionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "question")
+    private String question;
+
+    @Column(name = "criteria")
+    private String criteria;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/com/ddoddii/resume/model/question/BehaviorQuestion.java
+++ b/src/main/java/com/ddoddii/resume/model/question/BehaviorQuestion.java
@@ -1,0 +1,15 @@
+package com.ddoddii.resume.model.question;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "behavior_question")
+@AllArgsConstructor
+@Builder
+@Getter
+public class BehaviorQuestion extends BaseQuestionEntity {
+}

--- a/src/main/java/com/ddoddii/resume/model/question/IntroduceQuestion.java
+++ b/src/main/java/com/ddoddii/resume/model/question/IntroduceQuestion.java
@@ -1,0 +1,15 @@
+package com.ddoddii.resume.model.question;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "introduce_question")
+@AllArgsConstructor
+@Builder
+@Getter
+public class IntroduceQuestion extends BaseQuestionEntity {
+}

--- a/src/main/java/com/ddoddii/resume/model/question/PersonalQuestion.java
+++ b/src/main/java/com/ddoddii/resume/model/question/PersonalQuestion.java
@@ -1,0 +1,29 @@
+package com.ddoddii.resume.model.question;
+
+import com.ddoddii.resume.model.Interview;
+import com.ddoddii.resume.model.Resume;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "personal_question")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class PersonalQuestion extends BaseQuestionEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @ManyToOne
+    @JoinColumn(name = "interview_id")
+    private Interview interview;
+}

--- a/src/main/java/com/ddoddii/resume/model/question/TechQuestion.java
+++ b/src/main/java/com/ddoddii/resume/model/question/TechQuestion.java
@@ -1,0 +1,23 @@
+package com.ddoddii.resume.model.question;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tech_question")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class TechQuestion extends BaseQuestionEntity {
+    @Column(name = "topic")
+    private String topic;
+
+    @Column(name = "example_answer")
+    private String exampleAnswer;
+}

--- a/src/main/java/com/ddoddii/resume/repository/BehaviorQuestionRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/BehaviorQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.question.BehaviorQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BehaviorQuestionRepository extends JpaRepository<BehaviorQuestion, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/CompanyDeptRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/CompanyDeptRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.company.CompanyDept;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompanyDeptRepository extends JpaRepository<CompanyDept, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/CompanyJobRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/CompanyJobRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.company.CompanyJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompanyJobRepository extends JpaRepository<CompanyJob, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/CompanyNameRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/CompanyNameRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.company.CompanyName;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompanyNameRepository extends JpaRepository<CompanyName, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/EvaluationRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/EvaluationRepository.java
@@ -1,0 +1,8 @@
+package com.ddoddii.resume.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EvaluationRepository extends JpaRepository<EvaluationRepository, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/InterviewRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/InterviewRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/IntroduceQuestionRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/IntroduceQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.question.IntroduceQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IntroduceQuestionRepository extends JpaRepository<IntroduceQuestion, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/repository/TechQuestionRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/TechQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import com.ddoddii.resume.model.question.TechQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TechQuestionRepository extends JpaRepository<TechQuestion, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/service/UserService.java
+++ b/src/main/java/com/ddoddii/resume/service/UserService.java
@@ -4,11 +4,10 @@ import com.ddoddii.resume.dto.UserSignUpRequestDTO;
 import com.ddoddii.resume.error.errorcode.UserErrorCode;
 import com.ddoddii.resume.error.exception.DuplicateIdException;
 import com.ddoddii.resume.error.exception.NotExistIdException;
-import com.ddoddii.resume.model.RoleType;
 import com.ddoddii.resume.model.User;
+import com.ddoddii.resume.model.eunm.RoleType;
 import com.ddoddii.resume.repository.UserRepository;
 import com.ddoddii.resume.util.PasswordEncrypter;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -40,7 +39,6 @@ public class UserService {
         user.setName(userSignUpRequestDTO.getName());
         user.setEmail(userSignUpRequestDTO.getEmail());
         user.setRole(RoleType.USER);
-        user.setCreatedAt(LocalDateTime.now());
         return user;
     }
 


### PR DESCRIPTION
## 설명
> 데이터베이스 스키마 & JPA 레포지토리 생성


## 작업내용
>  자소서 기반 챗봇 서비스를 구현하기 위한 엔티티 저장 
- Company(CompanyName, CompanyDept, CompanyJob)
- Question(PersonalQuestion, TechQuestion, BehaviorQuestion)
- 인터뷰 세션을 저장하기 위한 Interview 엔티티 

> 반복되는 엔티티는 BaseEntity 로 추출 

## 데이터베이스 스키마

<img width="928" alt="image" src="https://github.com/f-lab-edu/resume-plus/assets/95014836/e6ce6274-eb3b-4a60-9843-8f7138554c87">
