### PR TITLE
OpenAI API 를 사용해서 개인 질문 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -42,6 +43,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     //Oauth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //openai api
+    implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.0-SNAPSHOT'
 
 }
 

--- a/src/main/java/com/ddoddii/resume/controller/ChatController.java
+++ b/src/main/java/com/ddoddii/resume/controller/ChatController.java
@@ -1,0 +1,24 @@
+package com.ddoddii.resume.controller;
+
+import com.ddoddii.resume.dto.PersonalQuestionDTO;
+import com.ddoddii.resume.service.QuestionGenService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/question/")
+@RequiredArgsConstructor
+public class ChatController {
+    private final QuestionGenService questionGenService;
+
+    @PostMapping("/generate/{resumeId}")
+    public List<PersonalQuestionDTO> generate(@PathVariable long resumeId) {
+        List<PersonalQuestionDTO> questionDTOS = questionGenService.generatePersonalQuestion(resumeId);
+        return questionDTOS;
+    }
+
+}

--- a/src/main/java/com/ddoddii/resume/dto/PersonalQuestionDTO.java
+++ b/src/main/java/com/ddoddii/resume/dto/PersonalQuestionDTO.java
@@ -1,0 +1,19 @@
+package com.ddoddii.resume.dto;
+
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PersonalQuestionDTO {
+    private String question;
+    private List<String> criteria;
+}

--- a/src/main/java/com/ddoddii/resume/error/errorcode/OpenAiErrorCode.java
+++ b/src/main/java/com/ddoddii/resume/error/errorcode/OpenAiErrorCode.java
@@ -1,0 +1,15 @@
+package com.ddoddii.resume.error.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OpenAiErrorCode implements ErrorCode {
+    JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Json Parse Error");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/ddoddii/resume/error/exception/JsonParseException.java
+++ b/src/main/java/com/ddoddii/resume/error/exception/JsonParseException.java
@@ -1,0 +1,11 @@
+package com.ddoddii.resume.error.exception;
+
+import com.ddoddii.resume.error.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class JsonParseException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/ddoddii/resume/error/exception/NotResumeOwnerException.java
+++ b/src/main/java/com/ddoddii/resume/error/exception/NotResumeOwnerException.java
@@ -1,0 +1,11 @@
+package com.ddoddii.resume.error.exception;
+
+import com.ddoddii.resume.error.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotResumeOwnerException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/ddoddii/resume/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ddoddii/resume/error/handler/GlobalExceptionHandler.java
@@ -4,8 +4,10 @@ import com.ddoddii.resume.error.ErrorResponse;
 import com.ddoddii.resume.error.errorcode.ErrorCode;
 import com.ddoddii.resume.error.exception.BadCredentialsException;
 import com.ddoddii.resume.error.exception.DuplicateIdException;
+import com.ddoddii.resume.error.exception.JsonParseException;
 import com.ddoddii.resume.error.exception.NotExistIdException;
 import com.ddoddii.resume.error.exception.NotExistResumeException;
+import com.ddoddii.resume.error.exception.NotResumeOwnerException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -40,10 +42,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode);
     }
 
+    @ExceptionHandler(JsonParseException.class)
+    public ResponseEntity<Object> handleJsonParseError(final JsonParseException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(NotResumeOwnerException.class)
+    public ResponseEntity<Object> handleJsonParseError(final NotResumeOwnerException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
     private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(makeErrorResponse(errorCode));
     }
+
 
     private ErrorResponse makeErrorResponse(final ErrorCode errorCode) {
         return ErrorResponse.builder()

--- a/src/main/java/com/ddoddii/resume/model/question/BaseQuestionEntity.java
+++ b/src/main/java/com/ddoddii/resume/model/question/BaseQuestionEntity.java
@@ -1,6 +1,7 @@
 package com.ddoddii.resume.model.question;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -11,7 +12,10 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 @SuperBuilder
@@ -24,7 +28,7 @@ public abstract class BaseQuestionEntity {
     @Column(name = "question")
     private String question;
 
-    @Column(name = "criteria")
+    @Column(name = "criteria", length = 2000)
     private String criteria;
 
     @CreatedDate

--- a/src/main/java/com/ddoddii/resume/model/question/BaseQuestionEntity.java
+++ b/src/main/java/com/ddoddii/resume/model/question/BaseQuestionEntity.java
@@ -7,11 +7,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @MappedSuperclass
 @Getter
+@SuperBuilder
+@NoArgsConstructor
 public abstract class BaseQuestionEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ddoddii/resume/model/question/PersonalQuestion.java
+++ b/src/main/java/com/ddoddii/resume/model/question/PersonalQuestion.java
@@ -7,16 +7,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "personal_question")
+@SuperBuilder
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-@Getter
 public class PersonalQuestion extends BaseQuestionEntity {
 
     @ManyToOne

--- a/src/main/java/com/ddoddii/resume/repository/PersonalQuestionRepository.java
+++ b/src/main/java/com/ddoddii/resume/repository/PersonalQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.ddoddii.resume.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PersonalQuestionRepository extends
+        JpaRepository<com.ddoddii.resume.model.question.PersonalQuestion, Long> {
+}

--- a/src/main/java/com/ddoddii/resume/service/QuestionGenService.java
+++ b/src/main/java/com/ddoddii/resume/service/QuestionGenService.java
@@ -1,0 +1,123 @@
+package com.ddoddii.resume.service;
+
+import com.ddoddii.resume.dto.PersonalQuestionDTO;
+import com.ddoddii.resume.error.errorcode.OpenAiErrorCode;
+import com.ddoddii.resume.error.errorcode.ResumeErrorCode;
+import com.ddoddii.resume.error.exception.JsonParseException;
+import com.ddoddii.resume.error.exception.NotExistResumeException;
+import com.ddoddii.resume.error.exception.NotResumeOwnerException;
+import com.ddoddii.resume.model.Resume;
+import com.ddoddii.resume.model.User;
+import com.ddoddii.resume.model.eunm.Position;
+import com.ddoddii.resume.model.question.PersonalQuestion;
+import com.ddoddii.resume.repository.PersonalQuestionRepository;
+import com.ddoddii.resume.repository.ResumeRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.chat.prompt.SystemPromptTemplate;
+import org.springframework.ai.openai.OpenAiChatClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@PropertySource("classpath:application-openai.yaml")
+@Slf4j
+public class QuestionGenService {
+    @Value("classpath:/prompts/perQ-gen-system.st")
+    private Resource perQGenSystemResource;
+
+    @Value("classpath:/prompts/perQ-gen-user.st")
+    private Resource perQGenUserResource;
+
+
+    private final OpenAiChatClient chatClient;
+    private final UserService userService;
+    private final PersonalQuestionRepository personalQuestionRepository;
+    private final ResumeRepository resumeRepository;
+    private final ObjectMapper objectMapper;
+
+
+    //개인 질문 생성
+    public List<PersonalQuestionDTO> generatePersonalQuestion(long resumeId) {
+        Resume resume = checkResumeOwner(resumeId);
+        Position position = resume.getPosition();
+        String resumeContent = resume.getContent();
+        Prompt prompt = generatePrompt(position.getName(), resumeContent);
+        ChatResponse response = chatClient.call(prompt);
+        List<PersonalQuestionDTO> questionDTOs = parseQuestions(response);
+
+        savePersonalQuestions(questionDTOs, resume);
+        return questionDTOs;
+    }
+
+    // 레쥬메 권한 확인
+    private Resume checkResumeOwner(long resumeId) {
+        User currentUser = userService.getCurrentUser();
+        Resume resume = resumeRepository.findById(resumeId).orElseThrow(() -> new NotExistResumeException(
+                ResumeErrorCode.NOT_EXIST_RESUME));
+        if (resume.getUser() != currentUser) {
+            throw new NotResumeOwnerException(ResumeErrorCode.NOT_RESUME_OWNER);
+        }
+        return resume;
+    }
+
+    // 포지션, 레쥬메 기반으로 프롬프트 생성
+    private Prompt generatePrompt(String position, String resumeContent) {
+        SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(perQGenSystemResource);
+        Message systemMessage = systemPromptTemplate.createMessage();
+        PromptTemplate userPromptTemplate = new PromptTemplate(perQGenUserResource);
+        Message userMessage = userPromptTemplate.createMessage(
+                Map.of("position", position, "resume", resumeContent));
+        return new Prompt(List.of(userMessage, systemMessage));
+    }
+
+    // Sting 에서 Json 형태로 파싱
+    private List<PersonalQuestionDTO> parseQuestions(ChatResponse response) {
+        String jsonResponse = response.getResult().getOutput().getContent();
+        List<PersonalQuestionDTO> questionList = new ArrayList<>();
+        try {
+            JsonNode rootNode = objectMapper.readTree(jsonResponse);
+            for (JsonNode questionNode : rootNode) {
+                String question = questionNode.get("question").asText();
+                log.info("parsed question :" + question);
+                List<String> criteria = new ArrayList<>();
+                for (JsonNode criteriaNode : questionNode.get("criteria")) {
+                    criteria.add(criteriaNode.asText());
+                }
+                questionList.add(PersonalQuestionDTO.builder().question(question).criteria(criteria).build());
+            }
+        } catch (IOException e) {
+            throw new JsonParseException(OpenAiErrorCode.JSON_PARSE_ERROR);
+        }
+        return questionList;
+    }
+
+    // 개인 질문 데이터베이스에 저장
+    private void savePersonalQuestions(List<PersonalQuestionDTO> personalQuestionDTOS, Resume resume) {
+        for (PersonalQuestionDTO personalQuestionDTO : personalQuestionDTOS) {
+            String criterias = StringUtils.join(personalQuestionDTO.getCriteria(), ", ");
+            PersonalQuestion personalQuestion = PersonalQuestion.builder()
+                    .resume(resume)
+                    .question(personalQuestionDTO.getQuestion())
+                    .criteria(criterias)
+                    .build();
+            personalQuestionRepository.save(personalQuestion);
+        }
+    }
+
+
+}

--- a/src/main/java/com/ddoddii/resume/service/QuestionGenService.java
+++ b/src/main/java/com/ddoddii/resume/service/QuestionGenService.java
@@ -14,6 +14,7 @@ import com.ddoddii.resume.repository.PersonalQuestionRepository;
 import com.ddoddii.resume.repository.ResumeRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @PropertySource("classpath:application-openai.yaml")
+@Transactional
 @Slf4j
 public class QuestionGenService {
     @Value("classpath:/prompts/perQ-gen-system.st")

--- a/src/main/resources/prompts/perQ-gen-system.st
+++ b/src/main/resources/prompts/perQ-gen-system.st
@@ -1,0 +1,1 @@
+You are a brilliant interviewer. You are a helpful assistant designed to output JSON.

--- a/src/main/resources/prompts/perQ-gen-user.st
+++ b/src/main/resources/prompts/perQ-gen-user.st
@@ -1,0 +1,20 @@
+You are an interviewer for {position}.
+You will be given a Resume and Position for an interview. Please make sure you read and understand these instructions carefully.
+Your task is to pick the top 5 critical experiences and generate interview questions for each.
+For each question, identify 3 evaluation keywords with detailed description that aligns with the provided question.
+
+[Resmue] : {resume}
+
+Respond in a structured JSON format. Please initiate your response with '['. WITHOUT ANY ADDITIONAL WORDS:
+[response format]:
+[
+{{
+  "question": "question 1",
+  "criteria": ["keyword : description", "keyword : description", "keyword : description"]
+}},
+{{
+  "question": "question 2",
+  "criteria": ["keyword : description", "keyword : description", "keyword : description"]
+}},
+...
+]


### PR DESCRIPTION
## 설명

> OpenAI API 를 사용해서 개인 질문 생성


## 작업내용
> 프롬프트 생성 
- Spring AI 의 `PromptTemplate`, `Message` 사용


## 질문 사항

- 현재 OpenAI API 사용해서 질문 생성 -> 생성한 질문을 디비에 저장으로 하다보니, 하나의 함수에 너무 많은 기능이 들어가게 되는 것 같습니다. (chatClient.call 로 질문 생성 요청 기다리기 + savePersonalQuestions 로 디비 저장). 하나의 함수에서 순차적인 로직으로 처리하는 방법말고 다른 방법이 있을까요..? 

```java
    public List<PersonalQuestionDTO> generatePersonalQuestion(long resumeId) {
        Resume resume = checkResumeOwner(resumeId);
        Position position = resume.getPosition();
        String resumeContent = resume.getContent();
        Prompt prompt = generatePrompt(position.getName(), resumeContent);
        ChatResponse response = chatClient.call(prompt);
        List<PersonalQuestionDTO> questionDTOs = parseQuestions(response);

        savePersonalQuestions(questionDTOs, resume);
        return questionDTOs;
    }
```
- 레쥬메의 실제 주인과 현재 로그인한 주인이 맞는지 확인하기 위해 아래의 로직을 작성했는데, 로그를 확인해보니 매번 디비에서 현재 사용자를 가져오는 작업을 해서 비효율적인 것 같습니다.. 현재 유저를 가져오는 방법에 이렇게 확인하는 방법 말고 다른 방법이 있을까요..? 

```java
    private Resume checkResumeOwner(long resumeId) {
        User currentUser = userService.getCurrentUser();
        Resume resume = resumeRepository.findById(resumeId).orElseThrow(() -> new NotExistResumeException(
                ResumeErrorCode.NOT_EXIST_RESUME));
        if (resume.getUser() != currentUser) {
            throw new NotResumeOwnerException(ResumeErrorCode.NOT_RESUME_OWNER);
        }
        return resume;
    }
```

```java
    // 현재 로그인한 유저 정보 반환
    public User getCurrentUser() {
        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
        String currentUserEmail = authentication.getName();
        return userRepository.findByEmail(currentUserEmail)
                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
    }
```